### PR TITLE
feat: distribute work amongst live workers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,4 +38,4 @@ jobs:
       - run: go version
 
       - name: Test
-        run: go test -v ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 
 .PHONY: test
 test:
-	go test ./...
+	go test -race -count=1 -covermode=atomic -coverprofile=coverage.out ./...
 
 # Assumes v3.5.0 mockery installed.
 gen-mocks:

--- a/pkg/partitionstorage/inmemory.go
+++ b/pkg/partitionstorage/inmemory.go
@@ -159,7 +159,7 @@ func (s *InmemoryPartitionStorage) UpdateToRunning(ctx context.Context, partitio
 }
 
 // UpdateToFinished marks the given partition as finished and sets the FinishedAt timestamp.
-func (s *InmemoryPartitionStorage) UpdateToFinished(ctx context.Context, partition *screamer.PartitionMetadata) error {
+func (s *InmemoryPartitionStorage) UpdateToFinished(ctx context.Context, partition *screamer.PartitionMetadata, runnerID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pkg/partitionstorage/migration.go
+++ b/pkg/partitionstorage/migration.go
@@ -72,9 +72,15 @@ func (s *SpannerPartitionStorage) RunMigrations(ctx context.Context) error {
 	partitionMetaIndexStmt := fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %[1]s_idx ON %[1]s(%[2]s) STORING (%[3]s, %[4]s, %[5]s, %[6]s, %[7]s, %[8]s, %[9]s, %[10]s, %[11]s)`,
 		s.tableName, columnWatermark, columnCreatedAt, columnEndTimestamp, columnFinishedAt, columnHeartbeatMillis, columnParentTokens, columnRunningAt, columnScheduledAt, columnStartTimestamp, columnState)
 
+	// Add PartitionCount column to Runner table if it doesn't exist
+	addPartitionCountStmt := fmt.Sprintf(`ALTER TABLE %[1]s ADD COLUMN IF NOT EXISTS %[2]s INT64 NOT NULL DEFAULT (0)`,
+		tableRunner,
+		columnPartitionCount,
+	)
+
 	req := &databasepb.UpdateDatabaseDdlRequest{
 		Database:   s.client.DatabaseName(),
-		Statements: []string{partitionStmt, partitionToRunnerStmt, runnerStmt, runnerIndexStmt, partitionMetaIndexStmt},
+		Statements: []string{partitionStmt, partitionToRunnerStmt, runnerStmt, runnerIndexStmt, partitionMetaIndexStmt, addPartitionCountStmt},
 	}
 	op, err := databaseAdminClient.UpdateDatabaseDdl(ctx, req)
 	if err != nil {

--- a/pkg/partitionstorage/spanner.go
+++ b/pkg/partitionstorage/spanner.go
@@ -72,8 +72,9 @@ const (
 	columnRunningAt       = "RunningAt"
 	columnFinishedAt      = "FinishedAt"
 
-	columnUpdatedAt = "UpdatedAt"
-	columnRunnerID  = "RunnerID"
+	columnUpdatedAt      = "UpdatedAt"
+	columnRunnerID       = "RunnerID"
+	columnPartitionCount = "PartitionCount"
 )
 
 // GetUnfinishedMinWatermarkPartition returns the unfinished partition with the minimum watermark.
@@ -117,9 +118,10 @@ func (s *SpannerPartitionStorage) GetUnfinishedMinWatermarkPartition(ctx context
 func (s *SpannerPartitionStorage) RegisterRunner(ctx context.Context, runnerID string) error {
 	log.Debug().Str("runner_id", runnerID).Msg("RegisterRunner called")
 	_, err := s.client.Apply(ctx, []*spanner.Mutation{spanner.InsertOrUpdateMap(tableRunner, map[string]interface{}{
-		columnRunnerID:  runnerID,
-		columnUpdatedAt: spanner.CommitTimestamp,
-		columnCreatedAt: spanner.CommitTimestamp,
+		columnRunnerID:       runnerID,
+		columnUpdatedAt:      spanner.CommitTimestamp,
+		columnCreatedAt:      spanner.CommitTimestamp,
+		columnPartitionCount: int64(0),
 	})}, spanner.TransactionTag("RegisterRunner"))
 	return err
 }
@@ -181,11 +183,6 @@ func (s *SpannerPartitionStorage) GetInterruptedPartitions(ctx context.Context, 
 				return err
 			}
 
-			// Use InsertOrUpdateMap for PartitionToRunner:
-			// - If partition was never assigned (ptr.PartitionToken IS NULL), this acts as an INSERT.
-			// - If partition was assigned to a stale runner (ptr.RunnerID IN StaleRunners), this acts as an UPDATE
-			//   to change RunnerID and update timestamps.
-			// CreatedAt will only be set if the row is new.
 			ptrMut := spanner.InsertOrUpdateMap(tablePartitionToRunner, map[string]interface{}{
 				columnPartitionToken: p.PartitionToken,
 				columnRunnerID:       runnerID,
@@ -198,16 +195,21 @@ func (s *SpannerPartitionStorage) GetInterruptedPartitions(ctx context.Context, 
 
 			mutations = append(mutations, ptrMut)
 			partitions = append(partitions, p)
-			// Individual partition reassignment attempt will be logged if transaction succeeds.
+
 			return nil
 		}); err != nil {
 			return fmt.Errorf("error processing partitions to reassign for runner %s: %w", runnerID, err)
 		}
 
-		if len(mutations) > 0 {
-			return tx.BufferWrite(mutations)
+		if len(partitions) > 0 {
+			updateRunnerMutation, err := s.updateRunnerPartitionCount(ctx, tx, runnerID, int64(len(partitions)))
+			if err != nil {
+				return fmt.Errorf("failed to update runner partition count for runner %s: %w", runnerID, err)
+			}
+			mutations = append(mutations, updateRunnerMutation)
 		}
-		return nil
+
+		return tx.BufferWrite(mutations)
 	}, spanner.TransactionOptions{TransactionTag: "GetInterruptedPartitions"})
 
 	if errOuter != nil {
@@ -257,9 +259,17 @@ func (s *SpannerPartitionStorage) GetAndSchedulePartitions(ctx context.Context, 
 	ts, err := s.client.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
 		partitions = make([]*screamer.PartitionMetadata, 0)
 		mutations := make([]*spanner.Mutation, 0, len(partitions))
+		canAssignPartitions, err := s.shouldAssignPartitionsToRunner(ctx, tx, runnerID)
+		if err != nil {
+			return fmt.Errorf("failed to check if runner %s should be assigned partitions: %w", runnerID, err)
+		}
+		// early exit if runner should not be assigned partitions (its already busy, leave some for others!)
+		if !canAssignPartitions {
+			return nil
+		}
 
 		stmt := spanner.Statement{
-			SQL: fmt.Sprintf("SELECT * FROM %s WHERE State = @state AND StartTimestamp >= @minWatermark ORDER BY StartTimestamp ASC FOR UPDATE", s.tableName),
+			SQL: fmt.Sprintf("SELECT * FROM %s WHERE State = @state AND StartTimestamp >= @minWatermark ORDER BY StartTimestamp ASC LIMIT 10 FOR UPDATE", s.tableName),
 			Params: map[string]interface{}{
 				"state":        screamer.StateCreated,
 				"minWatermark": minWatermark,
@@ -299,6 +309,16 @@ func (s *SpannerPartitionStorage) GetAndSchedulePartitions(ctx context.Context, 
 			return err
 		}
 
+		// Update runner's partition count if we scheduled any partitions
+		if len(partitions) > 0 {
+			updateRunnerMutation, err := s.updateRunnerPartitionCount(ctx, tx, runnerID, int64(len(partitions)))
+			if err != nil {
+				return fmt.Errorf("failed to update runner partition count for runner %s: %w", runnerID, err)
+			}
+
+			mutations = append(mutations, updateRunnerMutation)
+		}
+
 		// writes the updates to spanner.
 		return tx.BufferWrite(mutations)
 	}, spanner.TransactionOptions{TransactionTag: "GetAndSchedulePartitions"})
@@ -313,6 +333,76 @@ func (s *SpannerPartitionStorage) GetAndSchedulePartitions(ctx context.Context, 
 		Str("runner_id", runnerID).
 		Msg("GetAndSchedulePartitions completed")
 	return partitions, nil
+}
+
+func (s *SpannerPartitionStorage) updateRunnerPartitionCount(ctx context.Context, tx *spanner.ReadWriteTransaction, runnerID string, delta int64) (*spanner.Mutation, error) {
+	currentCount, err := s.getRunnerPartitionCount(ctx, tx, runnerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current partition count for runner %s: %w", runnerID, err)
+	}
+
+	updateRunnerMutation := spanner.UpdateMap(tableRunner, map[string]interface{}{
+		columnRunnerID:       runnerID,
+		columnPartitionCount: max(currentCount+delta, 0),
+		columnUpdatedAt:      spanner.CommitTimestamp,
+	})
+
+	return updateRunnerMutation, nil
+}
+
+func (s *SpannerPartitionStorage) getRunnerPartitionCount(ctx context.Context, tx *spanner.ReadWriteTransaction, runnerID string) (int64, error) {
+	row, err := tx.ReadRow(ctx, tableRunner, spanner.Key{runnerID}, []string{columnPartitionCount})
+	if err != nil {
+		return 0, err
+	}
+
+	var currentCount int64
+	if err := row.Columns(&currentCount); err != nil {
+		return 0, err
+	}
+
+	return currentCount, nil
+}
+
+func (s *SpannerPartitionStorage) shouldAssignPartitionsToRunner(ctx context.Context, tx *spanner.ReadWriteTransaction, runnerID string) (bool, error) {
+	stmt := spanner.Statement{
+		SQL: fmt.Sprintf(`
+			WITH ActiveRunners AS (
+				SELECT %[2]s, %[3]s
+				FROM %[1]s
+				WHERE %[4]s >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 SECOND)
+			)
+			SELECT COUNT(*) as ActiveRunnerCount, COALESCE(MIN(%[3]s), 0) as MinPartitionCount
+			FROM ActiveRunners
+		`, tableRunner, columnRunnerID, columnPartitionCount, columnUpdatedAt),
+	}
+
+	iter := tx.QueryWithOptions(ctx, stmt, spanner.QueryOptions{Priority: s.requestPriority})
+	defer iter.Stop()
+
+	row, err := iter.Next()
+	if err != nil {
+		return false, err
+	}
+
+	var activeRunnerCount int64
+	var minPartitionCount int64
+	if err := row.Columns(&activeRunnerCount, &minPartitionCount); err != nil {
+		return false, err
+	}
+
+	// If this is the only active runner, assign partitions
+	if activeRunnerCount == 1 {
+		return true, nil
+	}
+
+	// Check if this runner has the minimum partition count
+	currentCount, err := s.getRunnerPartitionCount(ctx, tx, runnerID)
+	if err != nil {
+		return false, err
+	}
+
+	return currentCount == minPartitionCount, nil
 }
 
 // AddChildPartitions adds new child partitions for a parent partition based on a ChildPartitionsRecord.
@@ -359,19 +449,33 @@ func (s *SpannerPartitionStorage) UpdateToRunning(ctx context.Context, partition
 }
 
 // UpdateToFinished marks the given partition as finished and sets the FinishedAt timestamp.
-func (s *SpannerPartitionStorage) UpdateToFinished(ctx context.Context, partition *screamer.PartitionMetadata) error {
+func (s *SpannerPartitionStorage) UpdateToFinished(ctx context.Context, partition *screamer.PartitionMetadata, runnerID string) error {
 	log.Debug().
 		Str("partition_token", partition.PartitionToken).
+		Str("runner_id", runnerID).
 		Msg("UpdateToFinished called")
-	m := spanner.UpdateMap(s.tableName, map[string]interface{}{
-		columnPartitionToken: partition.PartitionToken,
-		columnState:          screamer.StateFinished,
-		columnFinishedAt:     spanner.CommitTimestamp,
-	})
 
-	ts, err := s.client.Apply(ctx, []*spanner.Mutation{m}, spanner.Priority(s.requestPriority), spanner.TransactionTag("UpdateToFinished"))
-	partition.RunningAt = utils.ToPtr(ts.UTC())
-	return err
+	ts, err := s.client.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+		updateRunnerMutation, err := s.updateRunnerPartitionCount(ctx, tx, runnerID, -1)
+		if err != nil {
+			return fmt.Errorf("failed to update runner partition count for runner %s: %w", runnerID, err)
+		}
+
+		// Update partition state to finished
+		partitionMutation := spanner.UpdateMap(s.tableName, map[string]interface{}{
+			columnPartitionToken: partition.PartitionToken,
+			columnState:          screamer.StateFinished,
+			columnFinishedAt:     spanner.CommitTimestamp,
+		})
+
+		return tx.BufferWrite([]*spanner.Mutation{partitionMutation, updateRunnerMutation})
+	}, spanner.TransactionOptions{TransactionTag: "UpdateToFinished"})
+	if err != nil {
+		return err
+	}
+
+	partition.FinishedAt = utils.ToPtr(ts.CommitTs.UTC())
+	return nil
 }
 
 // UpdateWatermark updates the watermark for the given partition.

--- a/pkg/partitionstorage/spanner_test.go
+++ b/pkg/partitionstorage/spanner_test.go
@@ -980,6 +980,13 @@ func (s *SpannerTestSuite) TestSpannerPartitionStorage_GetAndSchedulePartitions(
 		for token, count := range tokenMap {
 			s.Equal(1, count, "Partition %s should only be scheduled once", token)
 		}
+		// Runners should be able to take new partitions if any.
+		shouldBeAssignable, err := storage.shouldAssignPartitionsToRunner(ctx, storage.client.ReadOnlyTransaction(), runner1ID)
+		s.NoError(err)
+		s.True(shouldBeAssignable, "Runner should be able to assign partitions")
+		shouldBeAssignable, err = storage.shouldAssignPartitionsToRunner(ctx, storage.client.ReadOnlyTransaction(), runner2ID)
+		s.NoError(err)
+		s.True(shouldBeAssignable, "Runner should be able to assign partitions")
 	})
 
 	s.Run("ScheduledAtTimestamp", func() {

--- a/pkg/partitionstorage/spanner_test.go
+++ b/pkg/partitionstorage/spanner_test.go
@@ -1016,7 +1016,7 @@ func (s *SpannerTestSuite) TestSpannerPartitionStorage_GetAndSchedulePartitions_
 		partition := scheduled[0]
 		s.NotNil(partition.ScheduledAt)
 		s.True(partition.ScheduledAt.After(beforeSchedule) || partition.ScheduledAt.Equal(beforeSchedule))
-		s.True(partition.ScheduledAt.Before(afterSchedule) || partition.ScheduledAt.Equal(afterSchedule))
+		s.GreaterOrEqual(partition.ScheduledAt.UnixMilli(), afterSchedule.UnixMilli())
 
 		// Verify in database
 		row, err := storage.client.Single().ReadRow(ctx, storage.tableName,

--- a/screamer.go
+++ b/screamer.go
@@ -269,7 +269,7 @@ func (s *Subscriber) queryChangeStream(ctx context.Context, p *PartitionMetadata
 	}
 
 	iter := s.spannerClient.Single().QueryWithOptions(ctx, stmt, spanner.QueryOptions{Priority: s.spannerRequestPriority})
-	defer iter.Stop()
+
 	if err := iter.Do(func(r *spanner.Row) error {
 		records := []*ChangeRecord{}
 		if err := r.Columns(&records); err != nil {

--- a/screamer.go
+++ b/screamer.go
@@ -33,7 +33,7 @@ type PartitionStorage interface {
 	// RefreshRunner updates the liveness timestamp for the given runnerID.
 	RefreshRunner(ctx context.Context, runnerID string) error
 	// UpdateToFinished marks the given partition as finished.
-	UpdateToFinished(ctx context.Context, partition *PartitionMetadata) error
+	UpdateToFinished(ctx context.Context, partition *PartitionMetadata, runnerID string) error
 	// UpdateWatermark updates the watermark for the given partition.
 	UpdateWatermark(ctx context.Context, partition *PartitionMetadata, watermark time.Time) error
 }
@@ -293,7 +293,7 @@ func (s *Subscriber) queryChangeStream(ctx context.Context, p *PartitionMetadata
 
 	log.Info().Str("partition_token", p.PartitionToken).
 		Msg("partition processing complete")
-	if err := s.partitionStorage.UpdateToFinished(ctx, p); err != nil {
+	if err := s.partitionStorage.UpdateToFinished(ctx, p, s.runnerID); err != nil {
 		return fmt.Errorf("failed to update to finished: %w", err)
 	}
 

--- a/screamer_test.go
+++ b/screamer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/anicoll/screamer/internal/helper"
 	"github.com/anicoll/screamer/pkg/interceptor"
 	"github.com/anicoll/screamer/pkg/partitionstorage"
-	"github.com/go-faker/faker/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -82,14 +82,13 @@ func (s *IntegrationTestSuite) AfterTest(suiteName, testName string) {
 	}
 }
 
-func createTableAndChangeStream(ctx context.Context, databaseName string) (string, string, error) {
+func createTableAndChangeStream(ctx context.Context, databaseName, tableName string) (string, string, error) {
 	databaseAdminClient, err := database.NewDatabaseAdminClient(ctx)
 	if err != nil {
 		return "", "", err
 	}
 	defer databaseAdminClient.Close()
 
-	tableName := faker.Word()
 	streamName := tableName + "Stream"
 
 	op, err := databaseAdminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
@@ -130,6 +129,7 @@ func createTableAndChangeStream(ctx context.Context, databaseName string) (strin
 }
 
 type consumerV2 struct {
+	mu      sync.Mutex
 	changes []*screamer.DataChangeRecordWithPartitionMeta
 }
 
@@ -138,11 +138,22 @@ func (c *consumerV2) Consume(change []byte) error {
 	if err := json.Unmarshal(change, dcr); err != nil {
 		return err
 	}
+	c.mu.Lock()
 	c.changes = append(c.changes, dcr)
+	c.mu.Unlock()
 	return nil
 }
 
+func (c *consumerV2) getChanges() []*screamer.DataChangeRecordWithPartitionMeta {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]*screamer.DataChangeRecordWithPartitionMeta, len(c.changes))
+	copy(result, c.changes)
+	return result
+}
+
 type consumerV1 struct {
+	mu      sync.Mutex
 	changes []*screamer.DataChangeRecord
 }
 
@@ -151,8 +162,18 @@ func (c *consumerV1) Consume(change []byte) error {
 	if err := json.Unmarshal(change, dcr); err != nil {
 		return err
 	}
+	c.mu.Lock()
 	c.changes = append(c.changes, dcr)
+	c.mu.Unlock()
 	return nil
+}
+
+func (c *consumerV1) getChanges() []*screamer.DataChangeRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make([]*screamer.DataChangeRecord, len(c.changes))
+	copy(result, c.changes)
+	return result
 }
 
 func (s *IntegrationTestSuite) TestSubscriber_inmemstorage() {
@@ -162,7 +183,7 @@ func (s *IntegrationTestSuite) TestSubscriber_inmemstorage() {
 	s.NoError(err)
 	runnerID := uuid.NewString()
 	s.T().Log("Creating table and change stream...")
-	tableName, streamName, err := createTableAndChangeStream(ctx, spannerClient.DatabaseName())
+	tableName, streamName, err := createTableAndChangeStream(ctx, spannerClient.DatabaseName(), "inmemstorage")
 	s.NoError(err)
 
 	s.T().Logf("Created table: %q, change stream: %q", tableName, streamName)
@@ -360,7 +381,7 @@ func (s *IntegrationTestSuite) TestSubscriber_inmemstorage() {
 	}
 	for _, test := range tests {
 		storage := partitionstorage.NewInmemory()
-		subscriber := screamer.NewSubscriber(spannerClient, streamName, runnerID, storage)
+		subscriber := screamer.NewSubscriber(spannerClient, streamName, runnerID, storage, screamer.WithSerializedConsumer(true))
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -392,8 +413,9 @@ func (s *IntegrationTestSuite) TestSubscriber_inmemstorage() {
 			cmpopts.IgnoreFields(screamer.DataChangeRecord{}, "CommitTimestamp", "ServerTransactionID", "RecordSequence", "NumberOfRecordsInTransaction"),
 			cmpopts.IgnoreFields(screamer.Mod{}, "OldValues", "NewValues"),
 		}
-		s.Assert().Len(consumer.changes, len(test.expected))
-		for _, change := range consumer.changes {
+		changes := consumer.getChanges()
+		s.Assert().Len(changes, len(test.expected))
+		for _, change := range changes {
 			switch change.ModType {
 			case screamer.ModType_INSERT:
 				diff := cmp.Diff(test.expected[0], change, opts...)
@@ -416,9 +438,8 @@ func (s *IntegrationTestSuite) TestSubscriber_spannerstorage() {
 	s.NoError(err)
 	runnerID := uuid.NewString()
 	s.T().Log("Creating table and change stream...")
-	tableName, streamName, err := createTableAndChangeStream(ctx, spannerClient.DatabaseName())
+	tableName, streamName, err := createTableAndChangeStream(ctx, spannerClient.DatabaseName(), "spannerstorage")
 	s.NoError(err)
-	metaTableName := faker.Word()
 
 	s.T().Logf("Created table: %q, change stream: %q", tableName, streamName)
 
@@ -614,10 +635,10 @@ func (s *IntegrationTestSuite) TestSubscriber_spannerstorage() {
 		},
 	}
 	for _, test := range tests {
-		storage := partitionstorage.NewSpanner(spannerClient, metaTableName)
+		storage := partitionstorage.NewSpanner(spannerClient, "metaTableName")
 		s.NoError(storage.RunMigrations(ctx))
 		s.NoError(storage.RegisterRunner(ctx, runnerID))
-		subscriber := screamer.NewSubscriber(spannerClient, streamName, runnerID, storage)
+		subscriber := screamer.NewSubscriber(spannerClient, streamName, runnerID, storage, screamer.WithSerializedConsumer(true))
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -649,8 +670,9 @@ func (s *IntegrationTestSuite) TestSubscriber_spannerstorage() {
 			cmpopts.IgnoreFields(screamer.DataChangeRecord{}, "CommitTimestamp", "ServerTransactionID", "RecordSequence", "NumberOfRecordsInTransaction"),
 			cmpopts.IgnoreFields(screamer.Mod{}, "OldValues", "NewValues"),
 		}
-		s.Assert().Len(consumer.changes, len(test.expected))
-		for _, change := range consumer.changes {
+		changes := consumer.getChanges()
+		s.Assert().Len(changes, len(test.expected))
+		for _, change := range changes {
 			switch change.ModType {
 			case screamer.ModType_INSERT:
 				diff := cmp.Diff(test.expected[0], change, opts...)
@@ -674,7 +696,7 @@ func (s *IntegrationTestSuite) TestSubscriber_spannerstorage_interrupted() {
 	s.NoError(err)
 	runnerID := uuid.NewString()
 	s.T().Log("Creating table and change stream...")
-	tableName, streamName, err := createTableAndChangeStream(ctx, spannerClient.DatabaseName())
+	tableName, streamName, err := createTableAndChangeStream(ctx, spannerClient.DatabaseName(), "interrupted")
 	s.NoError(err)
 	metaTableName := testTableName
 
@@ -698,6 +720,7 @@ func (s *IntegrationTestSuite) TestSubscriber_spannerstorage_interrupted() {
 		storage,
 		screamer.WithStartTimestamp(time.Now()),
 		screamer.WithHeartbeatInterval(1*time.Second),
+		screamer.WithSerializedConsumer(true),
 	)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -762,6 +785,7 @@ func (s *IntegrationTestSuite) TestSubscriber_spannerstorage_interrupted() {
 		storage,
 		screamer.WithStartTimestamp(time.Now()),
 		screamer.WithHeartbeatInterval(1*time.Second),
+		screamer.WithSerializedConsumer(true),
 	)
 
 	go func() {
@@ -785,12 +809,13 @@ func (s *IntegrationTestSuite) TestSubscriber_spannerstorage_interrupted() {
 	time.Sleep(time.Second * 1)
 
 	// Verify we received change records
-	s.T().Logf("Received %d changes", len(newConsumer.changes))
-	s.NotEmpty(newConsumer.changes, "Should have received at least one change record")
+	changes := newConsumer.getChanges()
+	s.T().Logf("Received %d changes", len(changes))
+	s.NotEmpty(changes, "Should have received at least one change record")
 
 	// At least one record should be for our table
 	var newTableRecords int
-	for _, r := range newConsumer.changes {
+	for _, r := range changes {
 		if r.TableName == tableName {
 			newTableRecords++
 		}


### PR DESCRIPTION
This is for distributed workers balancing load amongst themselves via the database.

* Runner Table has a new column called `PartitionCount`
* This column tracks the number of partitions a worker has at any one time.
* When a single Worker is running work is ALWAYS assigned the this worker.
* As new workers are assigned, they grab NEW partitions in a (least work) order meaning that the worker with the least work will take the next batch and increment its total working partitions.

**Caveats**
* Workers do not share partitions once they are owned (work is not redistributed or rebalanced) once running.
* Balancing occurs purely from ensuring new partitions are given to the worker with the least work
  * This means that it might take a short period of time for all work to be distributed amongst workers.